### PR TITLE
Fix RCTScrollView stickyHeader touch passing. [#99527680]

### DIFF
--- a/React/Views/RCTScrollView.m
+++ b/React/Views/RCTScrollView.m
@@ -352,7 +352,9 @@ RCT_NOT_IMPLEMENTED(-init)
     }
   }];
 
-  return stickyHeader ?: [super hitTest:point withEvent:event];
+  CGPoint convertedPoint = [stickyHeader convertPoint:point fromView:self];
+  return stickyHeader ? [stickyHeader hitTest:convertedPoint withEvent:event] :
+                        [super hitTest:point withEvent:event];
 }
 
 @end


### PR DESCRIPTION
Point must be converted to the stickyHeader's coordinate space and then passed to the stickyHeaders hitTest:withEvent: method in order to be correctly routed to any subviews of the stickyHeader