### PR TITLE
Add ServeStatic dependency for serving local assets packaged at the asset root.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "regenerator": "0.8.36",
     "sane": "^1.1.2",
     "semver": "^4.3.6",
+    "serve-static": "^1.10.0",
     "source-map": "0.1.31",
     "stacktrace-parser": "frantic/stacktrace-parser#493c5e5638",
     "uglify-js": "2.4.16",

--- a/packager/packager.js
+++ b/packager/packager.js
@@ -13,6 +13,7 @@ var path = require('path');
 var execFile = require('child_process').execFile;
 var http = require('http');
 var isAbsolutePath = require('absolute-path');
+var ServeStatic = require('serve-static');
 
 var getFlowTypeCheckMiddleware = require('./getFlowTypeCheckMiddleware');
 
@@ -242,6 +243,7 @@ function runServer(
   readyCallback
 ) {
   var app = connect()
+    .use(ServeStatic(options.assetRoots + '/assets', {'fallthrough':true}))
     .use(loadRawBody)
     .use(openStackFrameInEditor)
     .use(getDevToolsLauncher(options))


### PR DESCRIPTION
I'm concerned about hard coding `/assets`, I'm also concerned about the style of `{'fallthrough':true}`. It's required to ensure that if the asset isn't found, the JS files are still found, but it seems a bit out of place. Any ideas?

Perhaps we could have the ServeStatic just use `assetRoots` without the `/assets`, and then use `/assets/<fileName>` for our remote resources?