### PR TITLE
[#150281105] changed deepFreezeAndThrowOnMutationInDev.js for loops t…

### DIFF
--- a/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js
+++ b/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js
@@ -38,7 +38,10 @@ function deepFreezeAndThrowOnMutationInDev(object: Object) {
       return;
     }
 
-    for (var key in object) {
+    var keys = Object.keys(object);
+    
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
       if (object.hasOwnProperty(key)) {
         object.__defineGetter__(key, identity.bind(null, object[key]));
         object.__defineSetter__(key, throwOnImmutableMutation.bind(null, key));
@@ -48,7 +51,8 @@ function deepFreezeAndThrowOnMutationInDev(object: Object) {
     Object.freeze(object);
     Object.seal(object);
 
-    for (var key in object) {
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
       if (object.hasOwnProperty(key)) {
         deepFreezeAndThrowOnMutationInDev(object[key]);
       }


### PR DESCRIPTION
…o use for i rather than 'in'

For fix details see: https://github.com/KetoThrive/react-native/commit/0a604c7e4099f7fe0de404cec251141004f2f771 

For tag info see: https://git-scm.com/book/en/v2/Git-Basics-Tagging#_lightweight_tags