### PR TITLE
[PS-5586] Fix Android crash on transform with degrees in TouchableOpacity

### DIFF
--- a/Libraries/Animated/src/NativeAnimatedHelper.js
+++ b/Libraries/Animated/src/NativeAnimatedHelper.js
@@ -235,6 +235,22 @@ function shouldUseNativeDriver(config: AnimationConfig | EventConfig): boolean {
   return config.useNativeDriver || false;
 }
 
+function transformDataType(value: any): number {
+  // Change the string type to number type so we can reuse the same logic in
+  // iOS and Android platform
+  if (typeof value !== 'string') {
+    return value;
+  }
+  if (/deg$/.test(value)) {
+    const degrees = parseFloat(value) || 0;
+    const radians = (degrees * Math.PI) / 180.0;
+    return radians;
+  } else {
+    // Assume radians
+    return parseFloat(value) || 0;
+  }
+}
+
 module.exports = {
   API,
   validateStyles,
@@ -244,6 +260,7 @@ module.exports = {
   generateNewAnimationId,
   assertNativeAnimatedModule,
   shouldUseNativeDriver,
+  transformDataType,
   get nativeEventEmitter() {
     if (!nativeEventEmitter) {
       nativeEventEmitter = new NativeEventEmitter(NativeAnimatedModule);

--- a/Libraries/Animated/src/nodes/AnimatedInterpolation.js
+++ b/Libraries/Animated/src/nodes/AnimatedInterpolation.js
@@ -350,21 +350,7 @@ class AnimatedInterpolation extends AnimatedWithChildren {
   }
 
   __transformDataType(range: Array<any>) {
-    // Change the string array type to number array
-    // So we can reuse the same logic in iOS and Android platform
-    return range.map(function(value) {
-      if (typeof value !== 'string') {
-        return value;
-      }
-      if (/deg$/.test(value)) {
-        const degrees = parseFloat(value) || 0;
-        const radians = degrees * Math.PI / 180.0;
-        return radians;
-      } else {
-        // Assume radians
-        return parseFloat(value) || 0;
-      }
-    });
+    return range.map(NativeAnimatedHelper.transformDataType);
   }
 
   __getNativeConfig(): any {

--- a/Libraries/Animated/src/nodes/AnimatedTransform.js
+++ b/Libraries/Animated/src/nodes/AnimatedTransform.js
@@ -106,7 +106,7 @@ class AnimatedTransform extends AnimatedWithChildren {
           transConfigs.push({
             type: 'static',
             property: key,
-            value,
+            value: NativeAnimatedHelper.transformDataType(value),
           });
         }
       }


### PR DESCRIPTION
* An abbreviated cherry-pick of this PR on the React Native repo: https://github.com/facebook/react-native/pull/18872
* This fixes a rare Android crash where a transform on TouchableOpacitys followed by a tap would throw a type exception
* This strictly includes necessary changes and avoids adding tests and samples