### PR TITLE
convert RCTWebSocket error to [NSNull null] if it was nil, preventing…

### DIFF
--- a/Libraries/WebSocket/RCTWebSocketModule.m
+++ b/Libraries/WebSocket/RCTWebSocketModule.m
@@ -165,7 +165,7 @@ RCT_EXPORT_METHOD(close:(nonnull NSNumber *)socketID)
   _contentHandlers[socketID] = nil;
   _sockets[socketID] = nil;
   [self sendEventWithName:@"websocketFailed" body:@{
-    @"message": error.localizedDescription,
+    @"message": RCTNullIfNil(error.localizedDescription),
     @"id": socketID
   }];
 }


### PR DESCRIPTION
… crash

Copies the same nil-checking mechanism that's used one method below (originally made in [this commit](https://github.com/skillz/react-native/commit/86d4f4e20a89f4ff2c8fd3cc7972ec2518ba00c2) many moons ago). 

Checked over other spots in here that seemed like they could benefit from this and didn't see any, and decided since the crash only ever happened in this method that the others are probably good

As for why the error would be nil in the first place, not sure. I never did repro the crash locally, so I don't have a better answer, but at least now itll be handled a bit more gracefully