### PR TITLE
[PS-27965] fix missing image on ios 14

### DIFF
--- a/Libraries/Image/RCTUIImageViewAnimated.m
+++ b/Libraries/Image/RCTUIImageViewAnimated.m
@@ -269,6 +269,11 @@ static NSUInteger RCTDeviceFreeMemory() {
   if (_currentFrame) {
     layer.contentsScale = self.animatedImageScale;
     layer.contents = (__bridge id)_currentFrame.CGImage;
+  } else {
+    // Fixing image not showing on iOS 14.
+    // This should be fixed on RN 63.3, but was not ported to older RN versions.
+    // Issue can be found here: https://github.com/facebook/react-native/issues/29279#issuecomment-658244428
+    [super displayLayer:layer];
   }
 }
 


### PR DESCRIPTION
Pulling in a fix for local images not rendering on iOS 14. Issue can be found here: https://github.com/facebook/react-native/issues/29279#issuecomment-658244428

App icon image now appears correctly in the header of the "Change Name and Avatar" container:
![Simulator Screen Shot - iPhone 8 - 2020-10-19 at 08 54 30](https://user-images.githubusercontent.com/22797037/96481921-84a28a00-11f0-11eb-95cc-bbe75f144453.png)
